### PR TITLE
chore(deps): update deno dependencies

### DIFF
--- a/config/nvim/dein/settings/vim-lsp-settings.json
+++ b/config/nvim/dein/settings/vim-lsp-settings.json
@@ -89,7 +89,7 @@
               "deno.json",
               "deno.jsonc"
             ],
-            "url": "https://deno.land/x/deno@v1.24.1/cli/schemas/config-file.v1.json"
+            "url": "https://deno.land/x/deno@v1.24.2/cli/schemas/config-file.v1.json"
           },
           {
             "fileMatch": [
@@ -232,10 +232,10 @@
             "/efm-langserver/config.yaml",
             "/efm-langserver/config.yml"
           ],
-          "https://pax.deno.dev/aquaproj/aqua@v1.19.0-3/json-schema/aqua-yaml.json": [
+          "https://pax.deno.dev/aquaproj/aqua@v1.19.1/json-schema/aqua-yaml.json": [
             "/aqua/aqua.yaml"
           ],
-          "https://pax.deno.dev/aquaproj/aqua@v1.19.0-3/json-schema/registry.json": [
+          "https://pax.deno.dev/aquaproj/aqua@v1.19.1/json-schema/registry.json": [
             "/aqua-registry/pkgs/*/*/registry.yaml",
             "/aqua-registry/registry.yaml",
             "/aqua/experimental.yaml",

--- a/config/nvim/denops/@ddu-sources/pypi_classifiers.ts
+++ b/config/nvim/denops/@ddu-sources/pypi_classifiers.ts
@@ -5,8 +5,8 @@ import type {
 } from "https://deno.land/x/ddu_vim@v1.8.8/base/source.ts";
 import type { Item } from "https://deno.land/x/ddu_vim@v1.8.8/types.ts";
 import { BaseSource } from "https://deno.land/x/ddu_vim@v1.8.8/types.ts";
-import { readerFromStreamReader } from "https://deno.land/std@0.150.0/streams/conversion.ts";
-import { readLines } from "https://deno.land/std@0.150.0/io/mod.ts";
+import { readerFromStreamReader } from "https://deno.land/std@0.151.0/streams/conversion.ts";
+import { readLines } from "https://deno.land/std@0.151.0/io/mod.ts";
 
 type Params = Record<never, never>;
 

--- a/config/nvim/denops/@ddu-sources/quickfix.ts
+++ b/config/nvim/denops/@ddu-sources/quickfix.ts
@@ -1,4 +1,4 @@
-import * as fn from "https://deno.land/x/denops_std@v3.6.0/function/mod.ts";
+import * as fn from "https://deno.land/x/denops_std@v3.8.1/function/mod.ts";
 import type { ActionData } from "https://deno.land/x/ddu_kind_file@v0.3.0/file.ts";
 import type { GatherArguments } from "https://deno.land/x/ddu_vim@v1.8.8/base/source.ts";
 import type { Item } from "https://deno.land/x/ddu_vim@v1.8.8/types.ts";


### PR DESCRIPTION
Update deno dependencies by [udd](https://github.com/hayd/deno-udd):

```yaml
/home/runner/work/dotfiles/dotfiles/config/nvim/denops/@ddu-sources/pypi_classifiers.ts
[1/5] Looking for releases: https://deno.land/x/ddu_vim@v1.8.8/base/source.ts
[1/5] Using latest: https://deno.land/x/ddu_vim@v1.8.8/base/source.ts
[2/5] Looking for releases: https://deno.land/x/ddu_vim@v1.8.8/types.ts
[2/5] Using latest: https://deno.land/x/ddu_vim@v1.8.8/types.ts
[3/5] Looking for releases: https://deno.land/x/ddu_vim@v1.8.8/types.ts
[3/5] Using latest: https://deno.land/x/ddu_vim@v1.8.8/types.ts
[4/5] Looking for releases: https://deno.land/std@0.150.0/streams/conversion.ts
[4/5] Attempting update: https://deno.land/std@0.150.0/streams/conversion.ts -> 0.151.0
[4/5] Update successful: https://deno.land/std@0.150.0/streams/conversion.ts -> 0.151.0
[5/5] Looking for releases: https://deno.land/std@0.150.0/io/mod.ts
[5/5] Attempting update: https://deno.land/std@0.150.0/io/mod.ts -> 0.151.0
[5/5] Update successful: https://deno.land/std@0.150.0/io/mod.ts -> 0.151.0

/home/runner/work/dotfiles/dotfiles/config/nvim/denops/@ddu-sources/quickfix.ts
[1/5] Looking for releases: https://deno.land/x/denops_std@v3.6.0/function/mod.ts
[1/5] Attempting update: https://deno.land/x/denops_std@v3.6.0/function/mod.ts -> v3.8.1
[1/5] Update successful: https://deno.land/x/denops_std@v3.6.0/function/mod.ts -> v3.8.1
[2/5] Looking for releases: https://deno.land/x/ddu_kind_file@v0.3.0/file.ts
[2/5] Using latest: https://deno.land/x/ddu_kind_file@v0.3.0/file.ts
[3/5] Looking for releases: https://deno.land/x/ddu_vim@v1.8.8/base/source.ts
[3/5] Using latest: https://deno.land/x/ddu_vim@v1.8.8/base/source.ts
[4/5] Looking for releases: https://deno.land/x/ddu_vim@v1.8.8/types.ts
[4/5] Using latest: https://deno.land/x/ddu_vim@v1.8.8/types.ts
[5/5] Looking for releases: https://deno.land/x/ddu_vim@v1.8.8/types.ts
[5/5] Using latest: https://deno.land/x/ddu_vim@v1.8.8/types.ts

/home/runner/work/dotfiles/dotfiles/config/nvim/denops/@ddu-sources/scrapbox_pages.ts
[1/5] Looking for releases: https://deno.land/x/ddu_vim@v1.8.8/base/source.ts
[1/5] Using latest: https://deno.land/x/ddu_vim@v1.8.8/base/source.ts
[2/5] Looking for releases: https://deno.land/x/ddu_vim@v1.8.8/types.ts
[2/5] Using latest: https://deno.land/x/ddu_vim@v1.8.8/types.ts
[3/5] Looking for releases: https://deno.land/x/ddu_vim@v1.8.8/types.ts
[3/5] Using latest: https://deno.land/x/ddu_vim@v1.8.8/types.ts
[4/5] Looking for releases: https://pax.deno.dev/4513ECHO/ddu-kind-url@0.1.1/denops/@ddu-kinds/url.ts
[4/5] Using latest: https://pax.deno.dev/4513ECHO/ddu-kind-url@0.1.1/denops/@ddu-kinds/url.ts
[5/5] Looking for releases: https://pax.deno.dev/scrapbox-jp/types@0.3.5/rest.ts
[5/5] Using latest: https://pax.deno.dev/scrapbox-jp/types@0.3.5/rest.ts

/home/runner/work/dotfiles/dotfiles/config/nvim/template/typescript/base-ddu-kind.ts
[1/2] Looking for releases: https://deno.land/x/ddu_vim@v1.8.8/types.ts
[1/2] Using latest: https://deno.land/x/ddu_vim@v1.8.8/types.ts
[2/2] Looking for releases: https://deno.land/x/ddu_vim@v1.8.8/types.ts
[2/2] Using latest: https://deno.land/x/ddu_vim@v1.8.8/types.ts

/home/runner/work/dotfiles/dotfiles/config/nvim/template/typescript/base-ddu-source.ts
[1/3] Looking for releases: https://deno.land/x/ddu_vim@v1.8.8/base/source.ts
[1/3] Using latest: https://deno.land/x/ddu_vim@v1.8.8/base/source.ts
[2/3] Looking for releases: https://deno.land/x/ddu_vim@v1.8.8/types.ts
[2/3] Using latest: https://deno.land/x/ddu_vim@v1.8.8/types.ts
[3/3] Looking for releases: https://deno.land/x/ddu_vim@v1.8.8/types.ts
[3/3] Using latest: https://deno.land/x/ddu_vim@v1.8.8/types.ts

/home/runner/work/dotfiles/dotfiles/config/nvim/dein/settings/dein.toml.json

/home/runner/work/dotfiles/dotfiles/config/nvim/dein/settings/vim-lsp-settings.json
[1/3] Looking for releases: https://deno.land/x/deno@v1.24.1/cli/schemas/config-file.v1.json
[1/3] Attempting update: https://deno.land/x/deno@v1.24.1/cli/schemas/config-file.v1.json -> v1.24.2
[1/3] Update successful: https://deno.land/x/deno@v1.24.1/cli/schemas/config-file.v1.json -> v1.24.2
[2/3] Looking for releases: https://pax.deno.dev/aquaproj/aqua@v1.19.0-3/json-schema/aqua-yaml.json
[2/3] Attempting update: https://pax.deno.dev/aquaproj/aqua@v1.19.0-3/json-schema/aqua-yaml.json -> v1.19.1
[2/3] Update successful: https://pax.deno.dev/aquaproj/aqua@v1.19.0-3/json-schema/aqua-yaml.json -> v1.19.1
[3/3] Looking for releases: https://pax.deno.dev/aquaproj/aqua@v1.19.0-3/json-schema/registry.json
[3/3] Attempting update: https://pax.deno.dev/aquaproj/aqua@v1.19.0-3/json-schema/registry.json -> v1.19.1
[3/3] Update successful: https://pax.deno.dev/aquaproj/aqua@v1.19.0-3/json-schema/registry.json -> v1.19.1

/home/runner/work/dotfiles/dotfiles/config/nvim/snippets/_highlight_test.json

/home/runner/work/dotfiles/dotfiles/config/nvim/snippets/help.json

/home/runner/work/dotfiles/dotfiles/config/nvim/snippets/json.json

/home/runner/work/dotfiles/dotfiles/config/nvim/snippets/markdown.json

/home/runner/work/dotfiles/dotfiles/config/nvim/snippets/sh.json

/home/runner/work/dotfiles/dotfiles/config/nvim/snippets/toml.json

/home/runner/work/dotfiles/dotfiles/config/nvim/snippets/typescript.json

/home/runner/work/dotfiles/dotfiles/config/nvim/snippets/vim.json

/home/runner/work/dotfiles/dotfiles/config/python/pipx.json

/home/runner/work/dotfiles/dotfiles/renovate.json

/home/runner/work/dotfiles/dotfiles/.github/workflows/aqua.yaml

/home/runner/work/dotfiles/dotfiles/.github/workflows/prettier.yaml

/home/runner/work/dotfiles/dotfiles/.github/workflows/udd.yaml
[1/1] Looking for releases: https://deno.land/x/udd@0.7.5/main.ts
[1/1] Using latest: https://deno.land/x/udd@0.7.5/main.ts

/home/runner/work/dotfiles/dotfiles/config/aqua/aqua.yaml

/home/runner/work/dotfiles/dotfiles/config/aqua/experimental.yaml

/home/runner/work/dotfiles/dotfiles/config/efm-langserver/config.yaml

/home/runner/work/dotfiles/dotfiles/.github/workflows/aqua.yaml

/home/runner/work/dotfiles/dotfiles/.github/workflows/prettier.yaml

/home/runner/work/dotfiles/dotfiles/.github/workflows/udd.yaml
[1/1] Looking for releases: https://deno.land/x/udd@0.7.5/main.ts
[1/1] Using latest: https://deno.land/x/udd@0.7.5/main.ts

Already latest version:
https://deno.land/x/ddu_vim@v1.8.8/base/source.ts == v1.8.8
https://deno.land/x/ddu_vim@v1.8.8/types.ts == v1.8.8
https://deno.land/x/ddu_vim@v1.8.8/types.ts == v1.8.8
https://deno.land/x/ddu_kind_file@v0.3.0/file.ts == v0.3.0
https://deno.land/x/ddu_vim@v1.8.8/base/source.ts == v1.8.8
https://deno.land/x/ddu_vim@v1.8.8/types.ts == v1.8.8
https://deno.land/x/ddu_vim@v1.8.8/types.ts == v1.8.8
https://deno.land/x/ddu_vim@v1.8.8/base/source.ts == v1.8.8
https://deno.land/x/ddu_vim@v1.8.8/types.ts == v1.8.8
https://deno.land/x/ddu_vim@v1.8.8/types.ts == v1.8.8
https://pax.deno.dev/4513ECHO/ddu-kind-url@0.1.1/denops/@ddu-kinds/url.ts == 0.1.1
https://pax.deno.dev/scrapbox-jp/types@0.3.5/rest.ts == 0.3.5
https://deno.land/x/ddu_vim@v1.8.8/types.ts == v1.8.8
https://deno.land/x/ddu_vim@v1.8.8/types.ts == v1.8.8
https://deno.land/x/ddu_vim@v1.8.8/base/source.ts == v1.8.8
https://deno.land/x/ddu_vim@v1.8.8/types.ts == v1.8.8
https://deno.land/x/ddu_vim@v1.8.8/types.ts == v1.8.8
https://deno.land/x/udd@0.7.5/main.ts == 0.7.5
https://deno.land/x/udd@0.7.5/main.ts == 0.7.5

Successfully updated:
https://deno.land/std@0.150.0/streams/conversion.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/io/mod.ts 0.150.0 -> 0.151.0
https://deno.land/x/denops_std@v3.6.0/function/mod.ts v3.6.0 -> v3.8.1
https://deno.land/x/deno@v1.24.1/cli/schemas/config-file.v1.json v1.24.1 -> v1.24.2
https://pax.deno.dev/aquaproj/aqua@v1.19.0-3/json-schema/aqua-yaml.json v1.19.0-3 -> v1.19.1
https://pax.deno.dev/aquaproj/aqua@v1.19.0-3/json-schema/registry.json v1.19.0-3 -> v1.19.1

```

Pull Request is created by [create-pull-request](https://github.com/peter-evans/create-pull-request)