### PR TITLE
feat(vim): Introduce Neovim built-in LSP client

### DIFF
--- a/config/nvim/dein/ddc.toml
+++ b/config/nvim/dein/ddc.toml
@@ -31,6 +31,10 @@ repo = 'Shougo/ddc-source-line'
 repo = 'Shougo/ddc-source-mocword'
 
 [[plugins]]
+repo = 'Shougo/ddc-source-nvim-lsp'
+if = 'has("nvim")'
+
+[[plugins]]
 repo = 'Shougo/ddc-source-omni'
 
 [[plugins]]
@@ -47,7 +51,7 @@ repo = 'delphinus/ddc-tmux'
 [[plugins]]
 repo = 'hrsh7th/vim-vsnip'
 lazy = true
-on_source = 'ddc.vim'
+on_source = ['ddc.vim']
 hook_add = '''
 let g:vsnip_snippet_dir = g:config_home .. '/snippets'
 inoremap <expr> <C-l> vsnip#available(1) ? '<Plug>(vsnip-expand-or-jump)' : ''
@@ -59,6 +63,7 @@ repo = 'matsui54/ddc-buffer'
 
 [[plugins]]
 repo = 'shun/ddc-source-vim-lsp'
+if = '!has("nvim")'
 
 [[plugins]]
 repo = 'uga-rosa/ddc-source-vsnip'

--- a/config/nvim/dein/ddu.toml
+++ b/config/nvim/dein/ddu.toml
@@ -159,3 +159,6 @@ repo = 'shun/ddu-source-buffer'
 
 [[plugins]]
 repo = 'shun/ddu-source-rg'
+
+[[plugins]]
+repo = 'uga-rosa/ddu-source-lsp'

--- a/config/nvim/dein/neovim.toml
+++ b/config/nvim/dein/neovim.toml
@@ -1,4 +1,7 @@
 [[plugins]]
+repo = 'b0o/SchemaStore.nvim'
+
+[[plugins]]
 repo = 'chomosuke/term-edit.nvim'
 lazy = true
 on_event = ['TermOpen']
@@ -7,6 +10,13 @@ require("term-edit").setup {
   prompt_end = "❯ ",
   mapping = { n = { S = false } },
 }
+'''
+
+[[plugins]]
+repo = 'folke/neodev.nvim'
+on_event = ['LspAttach']
+lua_source = '''
+require("neodev").setup {}
 '''
 
 [[plugins]]
@@ -25,7 +35,39 @@ require("pasta").setup.filetype({ "markdown", "python", "yaml" }, {
 '''
 
 [[plugins]]
-repo = 'ii14/emmylua-nvim'
+repo = 'https://git.sr.ht/~whynothugo/lsp_lines.nvim'
+on_event = ['LspAttach']
+lua_source = '''
+require("lsp_lines").setup()
+vim.diagnostic.config { virtual_lines = false }
+vim.keymap.set("n", "[Toggle]d", function()
+  local config = vim.diagnostic.config()
+  vim.diagnostic.config {
+    virtual_text = not config.virtual_text,
+    virtual_lines = not config.virtual_lines,
+  }
+  vim.api.nvim_echo(
+    {
+      { "Diagnostic Mode: " },
+      { config.virtual_lines and "virtual_text" or "virtual_lines", "Constant" },
+    },
+    false,
+    {}
+  )
+end)
+'''
+
+[[plugins]]
+repo = 'j-hui/fidget.nvim'
+on_event = ['LspAttach']
+rev = 'legacy'
+lua_source = '''
+require("fidget").setup {
+  text = {
+    spinner = "dots_pulse",
+  },
+}
+'''
 
 [[plugins]]
 repo = 'kevinhwang91/nvim-hlslens'
@@ -40,6 +82,13 @@ lua_source = '''
 require("hlslens").setup {
   enable_incsearch = false,
 }
+'''
+
+[[plugins]]
+repo = 'neovim/nvim-lspconfig'
+on_event = ['BufRead']
+lua_source = '''
+require "vimrc.plugins.lsp"
 '''
 
 [[plugins]]
@@ -100,7 +149,6 @@ require("colorful-winsep").setup {
 
 [[plugins]]
 repo = 'rcarriga/nvim-notify'
-lazy = true
 on_lua = ['notify']
 lua_add = '''
 vim.notify = function(...) require "notify" (...) end
@@ -118,4 +166,11 @@ require("notify").setup {
     TRACE = "T",
   },
 }
+'''
+
+[[plugins]]
+repo = 'smjonas/inc-rename.nvim'
+on_event = ['LspAttach']
+lua_source = '''
+require("inc_rename").setup {}
 '''

--- a/config/nvim/dein/plugin.toml
+++ b/config/nvim/dein/plugin.toml
@@ -62,6 +62,7 @@ autocmd vimrc OptionSet buftype
 [[plugins]]
 repo = 'halkn/lightline-lsp'
 on_source = ['lightline.vim']
+if = '!has("nvim")'
 
 [[plugins]]
 repo = 'haya14busa/dein-command.vim'
@@ -140,7 +141,7 @@ let g:lightline = #{
       \   left: [
       \     ['mode', 'paste'],
       \     ['readonly', 'filename', 'modified'],
-      \     ['protocol', 'ddu', 'lsp_progress'],
+      \     ['protocol', 'ddu'] + (has('nvim') ? [] : ['lsp_progress']),
       \   ],
       \   right: [
       \     ['lsp_errors', 'lsp_warnings', 'lineinfo'],
@@ -165,8 +166,8 @@ let g:lightline = #{
       \   lineinfo: '%3l:%-2v',
       \ },
       \ component_expand: #{
-      \   lsp_errors: 'lightline_lsp#errors',
-      \   lsp_warnings: 'lightline_lsp#warnings',
+      \   lsp_errors: has('nvim') ? 'lightline#lsp#errors' :'lightline_lsp#errors',
+      \   lsp_warnings: has('nvim') ? 'lightline#lsp#warnings' :'lightline_lsp#warnings',
       \ },
       \ component_type: #{
       \   lsp_errors: 'error',
@@ -296,21 +297,6 @@ nnoremap g+    <Plug>(highlightedundo-gplus)
 '''
 
 [[plugins]]
-repo = 'mattn/vim-lsp-settings'
-depends = ['vim-lsp']
-on_event = ['BufRead']
-hook_add = '''
-Runtime dein/settings/vim-lsp.vim
-'''
-hook_source = '''
-if v:vim_did_enter
-  call timer_start(0, { -> lsp#enable() })
-else
-  autocmd vimrc VimEnter *  call timer_start(0, { -> lsp#enable() })
-endif
-'''
-
-[[plugins]]
 repo = 'mattn/vim-maketable'
 on_cmd = ['MakeTable', 'UnmakeTable']
 
@@ -357,6 +343,7 @@ endfunction
 [[plugins]]
 repo = 'micchy326/lightline-lsp-progress'
 on_source = ['lightline.vim']
+if = '!has("nvim")'
 
 [[plugins]]
 repo = 'ojroques/vim-oscyank'
@@ -387,10 +374,6 @@ let g:jplus#config = #{
       \   right_matchstr_pattern: '^\s*\\\s*\zs.*\|^\s*"\s*\zs.*\|\s*\zs.*',
       \ }}
 '''
-
-[[plugins]]
-repo = 'prabirshrestha/vim-lsp'
-on_source = ['vim-lsp-settings']
 
 [[plugins]]
 repo = 'shinchu/lightline-gruvbox.vim'
@@ -477,6 +460,16 @@ let g:Hexokinase_ftOptInPatterns = #{
       \ }
 let g:Hexokinase_ftDisabled = ['molder', 'ddu-ff', 'ddu-ff-filter']
 let g:Hexokinase_executable_path = exepath('hexokinase')
+'''
+
+[[plugins]]
+repo = 'spywhere/lightline-lsp'
+name = 'lightline-nvim-lsp'
+on_source = ['lightline.vim']
+if = 'has("nvim")'
+hook_add = '''
+let g:lightline#lsp#indicator_errors = '✗'
+let g:lightline#lsp#indicator_warnings = '‼'
 '''
 
 [[plugins]]

--- a/config/nvim/dein/settings/ddc.ts
+++ b/config/nvim/dein/settings/ddc.ts
@@ -5,6 +5,7 @@ import {
 
 export class Config extends BaseConfig {
   override config(args: ConfigArguments): Promise<void> {
+    const hasNvim = args.denops.meta.host === "nvim";
     const sources = ["file", "around", "vsnip", "tmux", "buffer"];
 
     args.contextBuilder.patchGlobal({
@@ -71,6 +72,10 @@ export class Config extends BaseConfig {
           isVolatile: true,
           maxItems: 8,
         },
+        "nvim-lsp": {
+          mark: "[lsp]",
+          forceCompletionPattern: "\\.|:\\s*|->\\s*",
+        },
         omni: {
           mark: "[omni]",
         },
@@ -115,6 +120,12 @@ export class Config extends BaseConfig {
           trailingSlash: true,
           followSymlinks: true,
         },
+        "nvim-lsp": {
+          snippetEngine: async (body: string) =>
+            await args.denops.call("vsnip#anonymous", body),
+          enableResolveItem: true,
+          enableAdditionalTextEdit: true,
+        },
         tmux: {
           currentWinOnly: true,
           excludeCurrentPane: true,
@@ -146,6 +157,9 @@ export class Config extends BaseConfig {
     });
     args.contextBuilder.patchFiletype("toml", {
       sourceOptions: {
+        "nvim-lsp": {
+          forceCompletionPattern: '\\.|[=#{[,"]\\s*',
+        },
         "vim-lsp": {
           forceCompletionPattern: '\\.|[=#{[,"]\\s*',
         },
@@ -167,7 +181,7 @@ export class Config extends BaseConfig {
       ]
     ) {
       args.contextBuilder.patchFiletype(ft, {
-        sources: ["vim-lsp", ...sources],
+        sources: [hasNvim ? "nvim-lsp" : "vim-lsp", ...sources],
       });
     }
     for (const ft of ["markdown", "gitcommit", "help"]) {

--- a/config/nvim/dein/settings/ddc.vim
+++ b/config/nvim/dein/settings/ddc.vim
@@ -30,7 +30,7 @@ endfunction
 inoremap <expr> <C-x><C-l> <SID>ddc_complete('line')
 inoremap <expr> <C-x><C-n> <SID>ddc_complete('around')
 inoremap <expr> <C-x><C-f> <SID>ddc_complete('file')
-inoremap <expr> <C-x><C-d> <SID>ddc_complete('vim-lsp')
+inoremap <expr> <C-x><C-d> <SID>ddc_complete(has('nvim') ? 'nvim-lsp' : 'vim-lsp')
 inoremap <expr> <C-x><C-v> <SID>ddc_complete('cmdline')
 inoremap <expr> <C-x><C-u> <SID>ddc_complete()
 inoremap <expr> <C-x><C-o> <SID>ddc_complete('omni')

--- a/config/nvim/dein/settings/ddu.ts
+++ b/config/nvim/dein/settings/ddu.ts
@@ -53,6 +53,8 @@ export class Config extends BaseConfig {
         file: { defaultAction: "open" },
         help: { defaultAction: "open" },
         highlight: { defaultAction: "edit" },
+        lsp: { defaultAction: "open" },
+        lsp_codeAction: { defaultAction: "apply" },
         readme_viewer: { defaultAction: "open" },
         source: { defaultAction: "execute" },
         "ui-select": { defaultAction: "execute" },
@@ -154,6 +156,16 @@ export class Config extends BaseConfig {
       uiParams: {
         ff: {
           autoAction: { name: "itemAction" },
+          startAutoAction: true,
+        } satisfies Partial<UiFFParams>,
+      },
+    });
+
+    args.contextBuilder.patchLocal("codeAction", {
+      sources: [{ name: "lsp_codeAction" }],
+      uiParams: {
+        ff: {
+          autoAction: { name: "preview" },
           startAutoAction: true,
         } satisfies Partial<UiFFParams>,
       },

--- a/config/nvim/dein/vim.toml
+++ b/config/nvim/dein/vim.toml
@@ -15,6 +15,21 @@ let g:traces_normal_preview = v:true
 '''
 
 [[plugins]]
+repo = 'mattn/vim-lsp-settings'
+depends = ['vim-lsp']
+on_event = ['BufRead']
+hook_add = '''
+Runtime dein/settings/vim-lsp.vim
+'''
+hook_source = '''
+if v:vim_did_enter
+  call timer_start(0, { -> lsp#enable() })
+else
+  autocmd vimrc VimEnter *  call timer_start(0, { -> lsp#enable() })
+endif
+'''
+
+[[plugins]]
 repo = 'mattn/vim-notification'
 lazy = true
 on_func = ['notification#']
@@ -38,6 +53,10 @@ repo = 'obcat/vim-sclow'
 hook_add = '''
 let g:sclow_hide_full_length = v:true
 '''
+
+[[plugins]]
+repo = 'prabirshrestha/vim-lsp'
+on_source = ['vim-lsp-settings']
 
 [[plugins]]
 repo = 'rbtnn/vim-coloredit'

--- a/config/nvim/denops/vimrc/main.ts
+++ b/config/nvim/denops/vimrc/main.ts
@@ -1,7 +1,8 @@
 import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
-import { assert, is } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
+import { ensure, is } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
 import { exists } from "https://deno.land/std@0.194.0/fs/exists.ts";
 import { join } from "https://deno.land/std@0.194.0/path/mod.ts";
+import { TextLineStream } from "https://deno.land/std@0.194.0/streams/text_line_stream.ts";
 
 export function main(denops: Denops): Promise<void> {
   denops.dispatcher = {
@@ -15,8 +16,8 @@ export function main(denops: Denops): Promise<void> {
       };
     },
 
-    async downloadJisyo(baseDir: unknown): Promise<unknown> {
-      assert(baseDir, is.String);
+    async downloadJisyo(arg: unknown): Promise<unknown> {
+      const baseDir = ensure(arg, is.String);
       if (await exists("/usr/share/skk/SKK-JISYO.L", { isFile: true })) {
         return "/usr/share/skk/SKK-JISYO.L";
       } else if (!(await exists(baseDir, { isDirectory: true }))) {
@@ -31,7 +32,53 @@ export function main(denops: Denops): Promise<void> {
       }
       return join(baseDir, "SKK-JISYO.L");
     },
+
+    async cacheLanguageServers(arg: unknown): Promise<void> {
+      const cacheDir = join(ensure(arg, is.String), "ls");
+      if ((await exists(cacheDir, { isDirectory: true }))) {
+        return;
+      }
+      await Deno.mkdir(cacheDir, { recursive: true });
+      const { stderr } = new Deno.Command("deno", {
+        args: [
+          "cache",
+          "--reload",
+          "--node-modules-dir",
+          "npm:@vtsls/language-server@0.1.20", //
+          "npm:yaml-language-server@1.13.0", //
+          "npm:prettier@2.8.8", //
+        ],
+        cwd: cacheDir,
+        stderr: "piped",
+        env: { NO_COLOR: "1" },
+      }).spawn();
+      stderr
+        .pipeThrough(new TextDecoderStream())
+        .pipeThrough(new TextLineStream())
+        .pipeTo(new EchomsgStream(denops));
+    },
   };
 
   return Promise.resolve();
+}
+
+class EchomsgStream extends WritableStream<string> {
+  constructor(denops: Denops) {
+    super({
+      write: (chunk) => {
+        this.#echo(denops, chunk);
+      },
+      close: () => {
+        this.#echo(denops, "Caching Done");
+        ["vtsls", "yamlls"].map((server) =>
+          denops.call("luaeval", "require('lspconfig')[_A].launch()", server)
+        );
+        this.#echo(denops, "Servers Restarted");
+      },
+    });
+  }
+
+  #echo(denops: Denops, chunk: string): void {
+    denops.call("nvim_echo", [["[Caching LS] ", "Comment"], [chunk]], true, []);
+  }
 }

--- a/config/nvim/lua/vimrc/autocmd.lua
+++ b/config/nvim/lua/vimrc/autocmd.lua
@@ -1,12 +1,36 @@
+---@diagnostic disable: duplicate-doc-field
 local M = {}
+
+---@type integer
 M.group = vim.api.nvim_create_augroup("nvim_vimrc", { clear = true })
 
+---Options for vim.api.nvim_create_autocmd()
+---@class AutocmdOptions
+---@field group? string|integer
+---@field pattern? string|string[]
+---@field buffer? integer
+---@field desc? string
+---@field callback? fun(ctx: AutocmdContext)|string
+---@field command? string
+---@field once? boolean
+---@field nested? boolean
+
+---@class AutocmdContext
+---@field id integer autocommand id
+---@field event string name of the triggered event |autocmd-event|
+---@field group integer|nil autocommand group id, if any
+---@field match string expanded value of <amatch>
+---@field buf integer expanded value of <abuf>
+---@field file string expanded value of <afile>
+---@field data any arbitary data passed from |nvim_exec_autocmds()|
+
 ---@param event string|string[]
----@return function
+---@return fun(opts: AutocmdOptions): integer
 function M.autocmd(event)
-  ---@param opts table
+  ---@param opts AutocmdOptions
+  ---@return integer
   return function(opts)
-    vim.api.nvim_create_autocmd(
+    return vim.api.nvim_create_autocmd(
       event,
       vim.tbl_deep_extend("force", { group = M.group, pattern = "*" }, opts)
     )

--- a/config/nvim/lua/vimrc/plugins/lsp/init.lua
+++ b/config/nvim/lua/vimrc/plugins/lsp/init.lua
@@ -1,0 +1,234 @@
+local autocmd = require("vimrc.autocmd").autocmd
+local lspconfig = require "lspconfig"
+local capabilities = require("ddc_nvim_lsp").make_client_capabilities()
+local root_pattern = lspconfig.util.root_pattern
+local deno_as_npm = require("vimrc.plugins.lsp.util").deno_as_npm
+local denops_notify = require("vimrc.plugins.lsp.util").denops_notify
+
+autocmd "LspAttach" {
+  callback = function(ctx)
+    local filetype =
+      vim.api.nvim_get_option_value("filetype", { buf = ctx.buf })
+    local opts = { buffer = true }
+    vim.keymap.set({ "n", "x" }, "gq", function()
+      vim.lsp.buf.format {
+        filter = function(client) return client.name ~= "taplo" end,
+      }
+    end, opts)
+    local K
+    if not vim.tbl_contains({ "lua", "markdown", "toml", "vim" }, filetype) then
+      K = vim.lsp.buf.hover
+    elseif filetype == "lua" then
+      K = require "vimrc.plugins.lsp.lua_help"
+    else
+      K = "K"
+    end
+    vim.keymap.set("n", "K", K, opts)
+    vim.keymap.set("n", "gK", vim.lsp.buf.hover, opts)
+    vim.keymap.set("n", "gd", vim.lsp.buf.definition, opts)
+    vim.keymap.set("n", "gi", vim.lsp.buf.implementation, opts)
+    vim.keymap.set("n", "gr", vim.lsp.buf.rename, opts)
+    -- vim.keymap.set(
+    --   "n",
+    --   "gr",
+    --   function() return ":IncRename " .. vim.fn.expand "<cword>" end,
+    --   { buffer = true, expr = true }
+    -- )
+    -- vim.keymap.set("n", "ma", vim.lsp.buf.code_action, opts)
+    vim.keymap.set({ "n", "x" }, "ma", "<Cmd>Ddu -name=codeAction<CR>", opts)
+    vim.keymap.set("n", "mf", vim.lsp.buf.references, opts)
+    vim.keymap.set("n", "md", vim.diagnostic.setloclist, opts)
+    vim.keymap.set("n", "]d", vim.diagnostic.goto_next, opts)
+    vim.keymap.set("n", "[d", vim.diagnostic.goto_prev, opts)
+  end,
+}
+
+autocmd "BufWritePre" {
+  pattern = "*.json",
+  callback = function() vim.lsp.buf.format { async = false, name = "efm" } end,
+}
+
+autocmd { "BufRead", "BufNewFile" } {
+  pattern = ".env",
+  callback = function(ctx) vim.diagnostic.disable(ctx.buf) end,
+}
+
+vim.lsp.handlers["textDocument/hover"] =
+  vim.lsp.with(vim.lsp.handlers.hover, { border = "single" })
+require("lspconfig.ui.windows").default_options.border = "single"
+
+vim.diagnostic.config { signs = { priority = 20 } }
+vim.fn.sign_define {
+  { name = "DiagnosticSignError", text = "✗", texthl = "DiagnosticError" },
+  { name = "DiagnosticSignWarn", text = "‼", texthl = "DiagnosticWarn" },
+  { name = "DiagnosticSignInfo", text = "i", texthl = "DiagnosticInfo" },
+  { name = "DiagnosticSignHint", text = "?", texthl = "DiagnosticHint" },
+}
+
+denops_notify "vimrc" "cacheLanguageServers" { vim.fn.stdpath "cache" }
+
+lspconfig.efm.setup {
+  filetypes = { "json", "lua", "markdown", "sh", "yaml" },
+}
+
+lspconfig.denols.setup {
+  capabilities = capabilities,
+  init_options = {
+    enable = true,
+    lint = true,
+    suggest = {
+      autoImports = false,
+      imports = {
+        hosts = {
+          ["https://deno.land"] = true,
+          ["https://crux.land"] = true,
+          ["https://x.nest.land"] = true,
+        },
+      },
+    },
+    unstable = true,
+  },
+  root_dir = root_pattern("deno.json", "deno.jsonc", "denops"),
+}
+
+lspconfig.vtsls.setup {
+  capabilities = capabilities,
+  -- cmd = deno_as_npm { "npm:@vtsls/language-server", "--stdio" },
+  -- cmd_env = deno_as_npm.cmd_env,
+  cmd = {
+    vim.fn.stdpath "cache"
+      .. "/ls/node_modules/@vtsls/language-server/bin/vtsls.js",
+    "--stdio",
+  },
+  single_file_support = false,
+  root_dir = root_pattern("package.json", "tsconfig.json", "jsconfig.json"),
+}
+
+lspconfig.lua_ls.setup {
+  capabilities = capabilities,
+  settings = {
+    Lua = {
+      completion = {
+        showWord = "Disable",
+      },
+      diagnostics = {
+        disable = { "lowercase-global" },
+        enable = true,
+        globals = { "vim" },
+      },
+      -- NOTE: Use stylua via efm-langserver instead.
+      format = { enable = false },
+      runtime = {
+        path = { "?.lua", "?/init.lua", "?/?.lua" },
+        version = "LuaJIT",
+      },
+      telemetry = { enable = false },
+      workspace = {
+        checkThirdParty = false,
+        library = vim.api.nvim_get_runtime_file("lua", true),
+        maxPreload = 1000,
+      },
+    },
+  },
+}
+
+lspconfig.gopls.setup {
+  capabilities = capabilities,
+}
+
+lspconfig.jsonls.setup {
+  capabilities = capabilities,
+  cmd = deno_as_npm {
+    "npm:vscode-langservers-extracted@4.7.0/vscode-json-language-server",
+    "--stdio",
+  },
+  cmd_env = deno_as_npm.cmd_env,
+  settings = {
+    json = {
+      schemas = require("schemastore").json.schemas {},
+      validate = { enable = true },
+    },
+  },
+}
+
+lspconfig.pylsp.setup {
+  capabilities = capabilities,
+  settings = {
+    pylsp = {
+      configurationSources = { "flake8" },
+      plugins = {
+        black = { enabled = true },
+        flake8 = { enabled = true },
+        meccabe = { enabled = false },
+        pycodestyle = { enabled = false },
+        pyflakes = { enabled = false },
+        pyls_isort = { enabled = true },
+        pylsp_mypy = {
+          enabled = true,
+          overrides = { "--no-pretty", true },
+          report_progress = true,
+        },
+      },
+    },
+  },
+}
+
+lspconfig.taplo.setup {
+  capabilities = capabilities,
+  settings = {
+    evenBetterToml = {
+      schema = {
+        associations = {
+          ["/dein/[^/]+\\.toml$"] = (
+            "file://"
+            .. vim.env.DEIN_DIR
+            .. "/settings/dein.toml.json"
+          ),
+        },
+      },
+    },
+  },
+}
+
+lspconfig.yamlls.setup {
+  -- cmd = deno_as_npm { "npm:yaml-language-server", "--stdio" },
+  -- cmd_env = deno_as_npm.cmd_env,
+  cmd = {
+    vim.fn.stdpath "cache"
+      .. "/ls/node_modules/yaml-language-server/bin/yaml-language-server",
+    "--stdio",
+  },
+  settings = {
+    yaml = {
+      completion = true,
+      hover = true,
+      validate = true,
+      -- NOTE: This option will disable the manual schema option also unfortunately.
+      -- schemaStore = { enable = false },
+      schemas = require("schemastore").yaml.schemas {
+        extra = {
+          {
+            fileMatch = "/efm-langserver/config.yaml",
+            name = "efm-langserver",
+            url = "https://mattn.github.io/efm-langserver/schema.json",
+          },
+          {
+            fileMatch = "/aqua/aqua.yaml",
+            name = "aqua.yaml",
+            url = "https://pax.deno.dev/aquaproj/aqua@v2.9.0/json-schema/aqua-yaml.json",
+          },
+          {
+            fileMatch = {
+              "/aqua-registry/pkgs/**/registry.yaml",
+              "/aqua-registry/registry.yaml",
+              "/aqua/experimental.yaml",
+              "/aqua/registry.yaml",
+            },
+            name = "aqua-registry",
+            url = "https://pax.deno.dev/aquaproj/aqua@v2.9.0/json-schema/registry.json",
+          },
+        },
+      },
+    },
+  },
+}

--- a/config/nvim/lua/vimrc/plugins/lsp/lua_help.lua
+++ b/config/nvim/lua/vimrc/plugins/lsp/lua_help.lua
@@ -1,0 +1,42 @@
+-- based on https://scrapbox.io/vim-jp/better_K_for_neovim_lua
+
+---@alias callback fun(str: string, str2: string|nil): string
+
+---@type callback
+local function convert_cmd(str) return ":" .. str end
+---@type callback
+local function convert_opt(str) return "'" .. str .. "'" end
+---@type callback
+local function convert_var(scope, name) return scope .. ":" .. name end
+
+local function lua_help()
+  local current_line = vim.api.nvim_get_current_line() ---@type string
+  local cursor_col = vim.api.nvim_win_get_cursor(0)[2] + 1 ---@type integer
+  for _, pattern in ipairs {
+    { "fn%.([%w_]+)" }, -- vim.fn.foo
+    { "fn%[['\"]([%w_#]+)['\"]%]" }, -- vim.fn["foo#bar"]
+    { "api%.([%w_]+)" }, -- vim.api.foo
+    { "vim%.cmd%.([%w_]+)", convert_cmd }, -- vim.cmd.foo
+    { "vim%.opt%.(%w+)", convert_opt }, -- vim.opt.foo
+    { "vim%.opt_local%.(%w+)", convert_opt }, -- vim.opt_local.foo
+    { "vim%.opt_global%.(%w+)", convert_opt }, -- vim.opt_global.foo
+    { "vim%.[gbw]?o%.(%w+)", convert_opt }, -- vim.wo.foo
+    { "vim%.([gwbtv])%.([%w_]+)", convert_var }, -- vim.g.foo, vim.v.bar
+    { "vim%.([gwbtv])%[['\"]([%w_#]+)['\"]%]", convert_var }, -- vim.g["foo#bar"]
+    { "(vim%.[%w_%.]+)" }, -- other vim.foo (e.g. vim.tbl_map, vim.lsp.foo, ...)
+  } do
+    ---@cast pattern { [1]: string, [2]: callback|nil }
+    local s, e, m1, m2 = current_line:find(pattern[1])
+    if s and s <= cursor_col and cursor_col <= e then
+      vim.cmd.help { pattern[2] and pattern[2](m1, m2) or m1 }
+      return true
+    end
+  end
+  return false
+end
+
+return function()
+  if not lua_help() then
+    vim.lsp.buf.hover()
+  end
+end

--- a/config/nvim/lua/vimrc/plugins/lsp/util.lua
+++ b/config/nvim/lua/vimrc/plugins/lsp/util.lua
@@ -1,0 +1,56 @@
+local M = {}
+
+---Helper function to replace language servers using npm with Deno.
+---
+---@example
+---```lua
+---require("lspconfig").vtsls.setup {
+---  cmd = deno_as_npm { "npm:@vtsls/language-server", "--stdio" },
+---  cmd_env = deno_as_npm.cmd_env,
+---}
+---```
+---@class deno_as_npm
+---@field cmd_env table<string, unknown> The `cmd_env` option for lspconfig-setup
+---@overload fun(cmd: string[]): string[]
+M.deno_as_npm = setmetatable({}, {
+  __call = function(_, cmd)
+    return vim.list_extend({
+      "deno",
+      "run",
+      "--allow-all",
+      "--no-config",
+      "--no-lock",
+      "--node-modules-dir=false",
+    }, cmd)
+  end,
+})
+M.deno_as_npm.cmd_env = { NO_COLOR = true }
+
+---@return { uri: string }[]
+function M.get_yaml_json_schema()
+  return vim
+    .iter(vim.lsp.get_active_clients { buffer = 0 })
+    :filter(function(client) return client.name == "yamlls" end)
+    :next()
+    .request_sync("yaml/get/jsonSchema", vim.uri_from_bufnr(0)).result
+end
+
+---@param name string
+---@return fun(method: string): fun(args: string[])
+function M.denops_notify(name)
+  ---@param method string
+  ---@return fun(args: string[])
+  return function(method)
+    ---@param args string[]
+    return function(args)
+      local function callback() vim.fn["denops#notify"](name, method, args) end
+      if vim.fn["denops#plugin#is_loaded"](name) > 0 then
+        callback()
+      else
+        vim.fn["denops#plugin#wait_async"](name, callback)
+      end
+    end
+  end
+end
+
+return M


### PR DESCRIPTION
WIP

- [x] Try [smjonas/inc-rename.nvim](https://github.com/smjonas/inc-rename.nvim)
- [x] Try [uga-rosa/ddu-source-lsp](https://github.com/uga-rosa/ddu-source-lsp)
- [x] Try [spywhere/lightline-lsp](https://github.com/spywhere/lightline-lsp) or [josa42/nvim-lightline-lsp](https://github.com/josa42/nvim-lightline-lsp)
- [x] Try [git.sr.ht/~whynothugo/lsp_lines.nvim](https://git.sr.ht/~whynothugo/lsp_lines.nvim) or [Maan2003/lsp_lines.nvim](https://github.com/Maan2003/lsp_lines.nvim) or [ErichDonGubler/lsp_lines.nvim](https://github.com/ErichDonGubler/lsp_lines.nvim)
- [x] Improve pylsp settings
- [x] Restore vim-lsp only for Vim
- [x] Add JSON schema settings for jsonls, taplo and yamlls
- [x] Add more mappings
- [x] Add vtsls and adjust root_patterns for denols
- [x] Issue about `npm:fixjson` deno support